### PR TITLE
Fix CI triggers for PR builds

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -7,6 +7,12 @@ on:
     paths-ignore:
       - 'README.md'
       - 'LICENSE'
+  pull_request:
+    branches:
+      - master
+    paths-ignore:
+      - 'README.md'
+      - 'LICENSE'
 
 jobs:
   build:
@@ -114,6 +120,7 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     needs: integration-test
+    if: github.event_name == 'push'
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
## Summary
- run CI for `pull_request` to master
- limit deploy to push events

## Testing
- `mvn test` *(fails: `mvn: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6842b89d81d08330b242edead546c0c0