### PR TITLE
Add aroma command

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ starting letters, e.g. `!cr` instead of `!crypto`. If the short command is ambig
 
 ### aroma
 - **Usage**: `!aroma <description>`
-- **Description**: Generates a wine aroma description from the given hint.
+- **Description**: Generates an aroma description based on the given hint.
 
 ### aireset
 - **Usage**: `!aireset`

--- a/README.md
+++ b/README.md
@@ -83,6 +83,10 @@ starting letters, e.g. `!cr` instead of `!crypto`. If the short command is ambig
 - **Usage**: `!lagerfeld <text>`
 - **Description**: Responds with an AI-generated Karl Lagerfeld quote.
 
+### aroma
+- **Usage**: `!aroma <description>`
+- **Description**: Generates a wine aroma description from the given hint.
+
 ### aireset
 - **Usage**: `!aireset`
 - **Description**: Deletes the current context for the channel and reloads the system prompt.

--- a/src/main/java/de/throughput/ircbot/handler/AromaCommandHandler.java
+++ b/src/main/java/de/throughput/ircbot/handler/AromaCommandHandler.java
@@ -1,0 +1,47 @@
+package de.throughput.ircbot.handler;
+
+import de.throughput.ircbot.api.Command;
+import de.throughput.ircbot.api.CommandEvent;
+import de.throughput.ircbot.api.CommandHandler;
+import org.springframework.stereotype.Component;
+
+import java.util.Set;
+
+/**
+ * Command handler for generating wine aroma descriptions using an LLM.
+ *
+ * Usage: !aroma <description>
+ */
+@Component
+public class AromaCommandHandler implements CommandHandler {
+
+    private static final Command CMD_AROMA = new Command("aroma",
+            "aroma <description> - describe a wine taste based on a short hint");
+
+    private static final String PROMPT_TEMPLATE =
+            "Beschreibe den Geschmack eines Weins, wie ein Weinkenner ihn beschreiben w\u00fcrde; " +
+            "antworte nur mit der Beschriebung des Geschmacks, ohne weitere Erkl\u00e4rung, " +
+            "und ohne Wein, Mund oder Gaumen zu erw\u00e4hnen; basierend auf folgendem Hinweis: '%s'; " +
+            "maximal 400 Zeichen";
+
+    private final SimpleAiService simpleAiService;
+
+    public AromaCommandHandler(SimpleAiService simpleAiService) {
+        this.simpleAiService = simpleAiService;
+    }
+
+    @Override
+    public Set<Command> getCommands() {
+        return Set.of(CMD_AROMA);
+    }
+
+    @Override
+    public boolean onCommand(CommandEvent command) {
+        command.getArgLine().ifPresentOrElse(desc -> {
+            String prompt = String.format(PROMPT_TEMPLATE, desc);
+            String response = simpleAiService.query(prompt);
+            command.respond(response);
+        }, () -> command.respond(CMD_AROMA.getUsage()));
+        return true;
+    }
+}

--- a/src/main/java/de/throughput/ircbot/handler/AromaCommandHandler.java
+++ b/src/main/java/de/throughput/ircbot/handler/AromaCommandHandler.java
@@ -8,7 +8,7 @@ import org.springframework.stereotype.Component;
 import java.util.Set;
 
 /**
- * Command handler for generating wine aroma descriptions using an LLM.
+ * Command handler for generating aroma descriptions using an LLM.
  *
  * Usage: !aroma <description>
  */
@@ -16,7 +16,7 @@ import java.util.Set;
 public class AromaCommandHandler implements CommandHandler {
 
     private static final Command CMD_AROMA = new Command("aroma",
-            "aroma <description> - describe a wine taste based on a short hint");
+            "aroma <description> - generate an aroma description based on the given hint");
 
     private static final String PROMPT_TEMPLATE =
             "Beschreibe den Geschmack eines Weins, wie ein Weinkenner ihn beschreiben w\u00fcrde; " +


### PR DESCRIPTION
## Summary
- add AromaCommandHandler for wine aroma descriptions via SimpleAiService
- document new `!aroma` command
- update aroma prompt length

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68848ee5b270833080a1a9ac2e66387c