### PR TITLE
Add calc command to evaluate expressions

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,10 @@ starting letters, e.g. `!cr` instead of `!crypto`. If the short command is ambig
 - **Usage**: `!flip <text>`
 - **Description**: Flips `<text>` over in rage.
 
+### calc
+- **Usage**: `!calc <expression>`
+- **Description**: Evaluates a mathematical expression and returns the result.
+
 ### lagerfeld
 - **Usage**: `!lagerfeld <text>`
 - **Description**: Responds with an AI-generated Karl Lagerfeld quote.

--- a/pom.xml
+++ b/pom.xml
@@ -96,6 +96,11 @@
             <version>1.17.2</version>
         </dependency>
         <dependency>
+            <groupId>net.objecthunter</groupId>
+            <artifactId>exp4j</artifactId>
+            <version>0.4.8</version>
+        </dependency>
+        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
             <version>2.0.13</version>

--- a/src/main/java/de/throughput/ircbot/handler/CalcCommandHandler.java
+++ b/src/main/java/de/throughput/ircbot/handler/CalcCommandHandler.java
@@ -1,0 +1,70 @@
+package de.throughput.ircbot.handler;
+
+import java.math.BigDecimal;
+import java.util.Optional;
+import java.util.Set;
+
+import org.springframework.stereotype.Component;
+
+import de.throughput.ircbot.api.Command;
+import de.throughput.ircbot.api.CommandEvent;
+import de.throughput.ircbot.api.CommandHandler;
+import net.objecthunter.exp4j.Expression;
+import net.objecthunter.exp4j.ExpressionBuilder;
+
+/**
+ * Calculator command handler.
+ * <p>
+ * calc &lt;expression&gt; evaluates a mathematical expression and responds with the result.
+ */
+@Component
+public class CalcCommandHandler implements CommandHandler {
+
+    private static final Command CMD_CALC = new Command("calc",
+            "calc <expression> evaluates a mathematical expression.");
+
+    @Override
+    public Set<Command> getCommands() {
+        return Set.of(CMD_CALC);
+    }
+
+    @Override
+    public boolean onCommand(CommandEvent command) {
+        if (!command.getCommand().equals(CMD_CALC)) {
+            return false;
+        }
+
+        command.getArgLine()
+                .map(String::trim)
+                .filter(arg -> !arg.isEmpty())
+                .ifPresentOrElse(
+                        expression -> evaluate(command, expression),
+                        () -> command.respond(CMD_CALC.getUsage()));
+        return true;
+    }
+
+    private void evaluate(CommandEvent command, String expressionString) {
+        try {
+            Expression expression = new ExpressionBuilder(expressionString).build();
+            double result = expression.evaluate();
+            if (Double.isNaN(result) || Double.isInfinite(result)) {
+                command.respond("error: result is not a finite number");
+            } else {
+                command.respond(formatResult(result));
+            }
+        } catch (RuntimeException e) {
+            command.respond("error: " + errorMessage(e));
+        }
+    }
+
+    private String formatResult(double result) {
+        BigDecimal decimal = BigDecimal.valueOf(result).stripTrailingZeros();
+        return decimal.toPlainString();
+    }
+
+    private String errorMessage(RuntimeException e) {
+        return Optional.ofNullable(e.getMessage())
+                .filter(message -> !message.isBlank())
+                .orElseGet(() -> e.getClass().getSimpleName());
+    }
+}

--- a/src/test/java/de/throughput/ircbot/integrationtest/IrcBotIT.java
+++ b/src/test/java/de/throughput/ircbot/integrationtest/IrcBotIT.java
@@ -61,6 +61,15 @@ class IrcBotIT {
     }
 
     @Test
+    void testCalc() throws Exception {
+        synchronized (listener) {
+            listener.expectMessage(TESTBOT_NICK + ": 42");
+            bot.sendIRC().message(CHANNEL, "!calc 7*6");
+            assertThat(listener.waitForMessage()).isTrue();
+        }
+    }
+
+    @Test
     void testAircraft() throws Exception {
         synchronized (listener) {
             listener.expectMessage(TESTBOT_NICK + ": https://www.flightradar24.com/data/aircraft/HB-JVN");


### PR DESCRIPTION
## Summary
- add the exp4j dependency for expression evaluation
- introduce a calc command handler that evaluates expressions and returns results or errors
- cover the calc command with an integration test that checks a simple multiplication

## Testing
- mvn -q test *(fails: com.github.pircbotx:pircbotx:pom:2.3.1 403 from jitpack.io)*

------
https://chatgpt.com/codex/tasks/task_e_68d77cc535388330ad3a542449d0887c