### PR TITLE
Add thread-safe 1s rate limiter for Alphavantage requests

### DIFF
--- a/src/main/java/de/throughput/ircbot/handler/StockAlphavantageCommandHandler.java
+++ b/src/main/java/de/throughput/ircbot/handler/StockAlphavantageCommandHandler.java
@@ -39,6 +39,9 @@ public class StockAlphavantageCommandHandler implements CommandHandler {
     private static final BigDecimal ONE_HUNDREDTH = new BigDecimal("0.01");
     private static final BigDecimal ONE_TENHOUSANDTH = new BigDecimal("0.0001");
     private static final String DEFAULT_CURRENCY = "USD";
+    private static final long RATE_LIMIT_INTERVAL_MS = 1_000L;
+    private static final Object RATE_LIMIT_LOCK = new Object();
+    private static long nextAllowedRequestTimeMs = 0L;
 
     private static final Command CMD_STOCK = new Command("stock", "stock <symbols> - get price information on stock symbols. example: !stock AMD");
 
@@ -127,6 +130,7 @@ public class StockAlphavantageCommandHandler implements CommandHandler {
     }
 
     private CompletableFuture<StockQuote> getStockQuote(String symbol) {
+        awaitRateLimit();
         URI uri = URI.create(String.format(API_URL_STOCK_QUOTE, symbol, apiKey));
 
         HttpRequest request = HttpRequest.newBuilder(uri)
@@ -137,6 +141,23 @@ public class StockAlphavantageCommandHandler implements CommandHandler {
         return HttpClient.newHttpClient()
                 .sendAsync(request, HttpResponse.BodyHandlers.ofString())
                 .thenApply(this::processStockQuoteResponse);
+    }
+
+    private static void awaitRateLimit() {
+        long delayMs;
+        synchronized (RATE_LIMIT_LOCK) {
+            long now = System.currentTimeMillis();
+            long scheduled = Math.max(now, nextAllowedRequestTimeMs);
+            nextAllowedRequestTimeMs = scheduled + RATE_LIMIT_INTERVAL_MS;
+            delayMs = scheduled - now;
+        }
+        if (delayMs > 0L) {
+            try {
+                Thread.sleep(delayMs);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        }
     }
 
     private StockQuote processStockQuoteResponse(HttpResponse<String> httpResponse) {


### PR DESCRIPTION
### Motivation
- Alphavantage free-tier enforces a one-request-per-second limit for stock quotes, so requests must be paced to avoid being rate-limited.
- The command can be invoked concurrently from multiple threads/channels, so the pacing needs to be shared and thread-safe.

### Description
- Added `RATE_LIMIT_INTERVAL_MS`, `RATE_LIMIT_LOCK`, and `nextAllowedRequestTimeMs` shared fields and invoked `awaitRateLimit()` before each call to `getStockQuote` to enforce the interval.
- Implemented `awaitRateLimit()` which synchronizes on `RATE_LIMIT_LOCK`, computes the required delay to preserve a global 1s spacing, updates `nextAllowedRequestTimeMs`, and sleeps the current thread preserving interrupt status.
- Applied the rate limiter in `StockAlphavantageCommandHandler` so all threads share the same schedule when calling the Alphavantage API.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6967841f40a48330b83b21c0639673a9)